### PR TITLE
feat(ssh): sshd設定とauthorized_keysをdotfilesで管理

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@
     - name: アルファベットフルネーム
     - email: sshキーの設定と同一のGithubで利用しているメールアドレス
 
-5. VSCodeのClineのCustom Instructionsを手動で設定する
+5. sshdを再起動して設定を反映する
+
+    ```zsh
+    sudo launchctl stop com.openssh.sshd
+    sudo launchctl start com.openssh.sshd
+    ```
+
+6. VSCodeのClineのCustom Instructionsを手動で設定する
 
     現状設定のエクスポートなどができず、`settings.json`ファイルでの外出しも不可能なため手動
 

--- a/init-mac.zsh
+++ b/init-mac.zsh
@@ -260,6 +260,31 @@ else
   print_warning "Extension ID: saoudrizwan.claude-dev"
 fi
 
+# sshd configuration
+# /etc/ssh/sshd_config is a system file, so sudo is required
+if [[ -e /etc/ssh/sshd_config && ! -L /etc/ssh/sshd_config ]]; then
+  local backup_path="/etc/ssh/sshd_config.bak.$(date +%Y%m%d%H%M%S)"
+  sudo cp /etc/ssh/sshd_config $backup_path
+  print_warning "Existing sshd_config backed up to $backup_path"
+fi
+sudo ln -nfs $SCRIPT_DIR/sshd/sshd_config /etc/ssh/sshd_config
+print_success "sshd configuration file created"
+print_info "To apply sshd configuration, restart sshd with the following commands:"
+print_info "  sudo launchctl stop com.openssh.sshd"
+print_info "  sudo launchctl start com.openssh.sshd"
+
+# SSH authorized_keys configuration
+mkdir -p $HOME/.ssh
+chmod 700 $HOME/.ssh
+if [[ -e $HOME/.ssh/authorized_keys && ! -L $HOME/.ssh/authorized_keys ]]; then
+  local backup_path="$HOME/.ssh/authorized_keys.bak.$(date +%Y%m%d%H%M%S)"
+  cp $HOME/.ssh/authorized_keys $backup_path
+  print_warning "Existing authorized_keys backed up to $backup_path"
+fi
+cp $SCRIPT_DIR/ssh/authorized_keys $HOME/.ssh/authorized_keys
+chmod 600 $HOME/.ssh/authorized_keys
+print_success "SSH authorized_keys configuration file copied"
+
 # iTerm2 shell integration install
 curl -sL https://iterm2.com/shell_integration/zsh -o $HOME/.iterm2_shell_integration.zsh
 print_success "iTerm2 shell integration installed"

--- a/ssh/authorized_keys
+++ b/ssh/authorized_keys
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH8MiWsjsTJsFLYwzxZy9VVbKLrNYYeq9ilxMbDppNUp iphone-tailscale

--- a/sshd/sshd_config
+++ b/sshd/sshd_config
@@ -1,0 +1,129 @@
+#	$OpenBSD: sshd_config,v 1.104 2021/07/02 05:11:21 dtucker Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+# NOTE: The following Include directive is not part of the default
+# sshd_config shipped with OpenSSH. Options set in the included
+# configuration files generally override those that follow. The defaults
+# only apply to options that have not been explicitly set. Options that
+# appear multiple times keep the first value set, unless they are a
+# multivalue option such as HostKey or IdentityFile.
+Include /etc/ssh/sshd_config.d/*
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+UsePAM no
+AuthenticationMethods publickey
+
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+#PasswordAuthentication yes
+#PermitEmptyPasswords no
+
+# Change to no to disable s/key passwords
+#KbdInteractiveAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the KbdInteractiveAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via KbdInteractiveAuthentication may bypass
+# the setting of "PermitRootLogin prohibit-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and KbdInteractiveAuthentication to 'no'.
+#UsePAM no
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+#X11Forwarding no
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# override default of no subsystems
+Subsystem	sftp	/usr/libexec/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server


### PR DESCRIPTION
## Summary

- `sshd/sshd_config` を追加し、パスワード認証無効・公開鍵認証のみを許可するSSHサーバー設定をdotfilesで管理
- `ssh/authorized_keys` を追加し、SSHログインを許可する公開鍵をdotfilesで管理
- `init-mac.zsh` に `sshd_config` のシンボリックリンク作成と `authorized_keys` のコピーを自動化する処理を追加
- `README.md` にsshd再起動手順をセットアップ手順に追記

## Test plan

- [x] `init-mac.zsh` を実行して `/etc/ssh/sshd_config` がシンボリックリンクとして配置されることを確認
- [x] `init-mac.zsh` を実行して `~/.ssh/authorized_keys` がコピーされ、パーミッション600で配置されることを確認
- [x] sshdを再起動して公開鍵認証でSSH接続できることを確認
- [x] パスワード認証が拒否されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)