### PR TITLE
feat(statusline): コンテキスト使用率80%超えで赤色表示

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,11 @@
 {
-  "enableAllProjectMcpServers": false,
   "permissions": {
     "allow": [
-      "WebSearch"
+      "WebSearch",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
     ]
-  }
+  },
+  "enableAllProjectMcpServers": false
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "WebSearch",
       "Bash(git checkout:*)",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(gh pr create:*)"
     ]
   },
   "enableAllProjectMcpServers": false

--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -1,3 +1,7 @@
 {
-  "language": "日本語"
+  "language": "日本語",
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
+  }
 }

--- a/claude-code/statusline.sh
+++ b/claude-code/statusline.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Claude Code から stdin 経由で渡される JSON を読み込む
+input=$(cat)
+
+# コンテキスト使用率（%）を整数に丸める
+# used_percentage = (input_tokens + cache_tokens) / context_window_size * 100
+PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | awk '{printf "%.0f", $1}')
+
+# 実際の使用トークン数（input + cache_creation + cache_read の合計）
+USED=$(echo "$input" | jq -r '
+  (.context_window.current_usage.input_tokens // 0)
+  + (.context_window.current_usage.cache_creation_input_tokens // 0)
+  + (.context_window.current_usage.cache_read_input_tokens // 0)')
+
+# 最大コンテキストウィンドウサイズ（トークン数）
+TOTAL=$(echo "$input" | jq -r '.context_window.context_window_size // 0')
+
+# モデル名と現在のディレクトリを取得
+MODEL_DISPLAY=$(echo "$input" | jq -r '.model.display_name')
+CURRENT_DIR=$(echo "$input" | jq -r '.workspace.current_dir')
+
+# Gitリポジトリの場合にブランチ名を取得
+GIT_BRANCH=""
+if git rev-parse --git-dir > /dev/null 2>&1; then
+    BRANCH=$(git branch --show-current 2>/dev/null)
+    if [ -n "$BRANCH" ]; then
+        GIT_BRANCH=" | 🌿 $BRANCH"
+    fi
+fi
+
+# コンテキスト使用率が80%以上の場合は赤色にする
+RED='\033[31m'
+RESET='\033[0m'
+
+if [ "$PCT" -ge 80 ]; then
+    CONTEXT_TEXT="${RED}Context: ${PCT}% (${USED}/${TOTAL} tokens)${RESET}"
+else
+    CONTEXT_TEXT="Context: ${PCT}% (${USED}/${TOTAL} tokens)"
+fi
+
+# ステータスラインに出力（例: "Context: 42% (85000/200000 tokens)  [Sonnet 4.6] 📁 org/my_project | 🌿 develop）
+echo -e "${CONTEXT_TEXT}  [$MODEL_DISPLAY] 📁 ${CURRENT_DIR##*github.com/}$GIT_BRANCH"

--- a/init-mac.zsh
+++ b/init-mac.zsh
@@ -239,7 +239,8 @@ mkdir -p $HOME/.claude
 ln -nfs $SCRIPT_DIR/claude-code/CLAUDE.md $HOME/.claude/CLAUDE.md
 ln -nfs $SCRIPT_DIR/claude-code/skills $HOME/.claude/skills
 ln -nfs $SCRIPT_DIR/claude-code/settings.json $HOME/.claude/settings.json
-print_success "Claude Code user-level CLAUDE.md, skills and settings created"
+ln -nfs $SCRIPT_DIR/claude-code/statusline.sh $HOME/.claude/statusline.sh
+print_success "Claude Code user-level CLAUDE.md, skills, settings and statusline created"
 
 # Cline MCP settings
 print_section "VSCode Cline extension Configuration"


### PR DESCRIPTION
## Summary

- `claude-code/statusline.sh` を新規追加し、コンテキスト使用率が80%以上の場合にANSIエスケープコードで赤色表示する機能を実装
- `claude-code/settings.json` にstatusLine設定（commandタイプ）を追加
- `init-mac.zsh` にstatusline.shのシンボリックリンク作成処理を追加

## Test plan

- [x] `init-mac.zsh` を実行して `~/.claude/statusline.sh` のシンボリックリンクが正しく作成されることを確認
- [x] Claude Codeを起動してステータスラインにコンテキスト情報が表示されることを確認
- [x] コンテキスト使用率が80%未満の場合は通常色で表示されることを確認
- [x] コンテキスト使用率が80%以上の場合に赤色で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)