### PR TITLE
chore(vscode): markdownlintのMD036ルールを無効化

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -311,6 +311,7 @@
   "claudeCode.preferredLocation": "panel",
   // markdownlint: ルール設定
   "markdownlint.config": {
+    "MD036": false,
     "MD040": false,
     "MD060": false,
   },


### PR DESCRIPTION
## Summary

- `vscode/settings.json` に markdownlint の `MD036` ルールの無効化設定を追加
- MD036は「見出しスタイルの強調」に関するルールで、MarkdownでのEmphasisを見出し代わりに使う記法を検知する

## Test plan

- [x] VSCodeでMarkdownファイルを開き、MD036に関するlintエラーが表示されないことを確認
- [x] 他のmarkdownlintルール（MD040、MD060）が引き続き無効化されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)