### PR TITLE
feat(dotfiles): tmuxサポートの追加とinstall_commandの更新機能追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ id_ed25519
 *.tmp
 *.log
 *.bak
+
+# Claude Code
+.claude/plans/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,43 @@
 **mise**で管理できるものはすべてmiseで管理する
 
 **SDKMAN**がJavaバージョンを管理する
+
+## 初期化スクリプト
+
+### `init-mac.zsh`
+
+新規macOS環境のセットアップを自動化するスクリプト。macOS以外では実行不可。
+以下の処理を順番に行う：
+
+1. **パッケージマネージャーのインストール**: Nix（パッケージ管理のメイン）・Homebrew（一部パッケージ用）
+2. **Zsh設定**: `zsh/.zshrc` をホームディレクトリへシンボリックリンク
+3. **Xcode Command Line Toolsのインストール**
+4. **開発ツールのインストール**（未インストールの場合のみ）:
+   - Git、ghq、GitHub CLI、curl、fzf（Nixで管理）
+   - mise（マルチ言語バージョンマネージャー）、Go（Nixで管理）
+   - SDKMAN（Java用バージョンマネージャー）
+   - Python、Node.js（LTS）、pnpm、Bun（miseで管理）
+   - Claude Code、Codex CLI、AWS CLI、AWS SAM CLI
+   - フォント（Fira Code）、ngrok、Stripe CLI、VHS
+5. **Javaのインストール**（SDKMANで管理）: Java 11 / 17 / 18（Amazon Corretto）
+6. **設定ファイルのシンボリックリンク作成**: Git・Cursor・VSCode・VSCode Insiders・Claude Code
+7. **Cline拡張設定のコピー**（VSCode Cline拡張が存在する場合のみ）
+8. **SSH設定**: `sshd_config` を `/etc/ssh/` へシンボリックリンク（要sudo）、`authorized_keys` をコピー
+9. **iTerm2シェルインテグレーションのインストール**
+10. **macOSシステム設定**: キーリピート速度、DNS（Google Public DNS）、Finder設定など
+
+## ディレクトリ構成
+
+| ディレクトリ | 説明 |
+| --- | --- |
+| `.claude/` | このリポジトリ用のClaude Code設定（`settings.json`、planファイル） |
+| `claude-code/` | ユーザーレベルのClaude Code設定 |
+| `cursor/` | Cursorエディタの設定（`settings.json`、`keybindings.json`） |
+| `git/` | Git設定（`.gitconfig`、`.gitconfig.user.local`、`.gitignore_global`） |
+| `iterm2/` | iTerm2の設定・プロファイル・カラースキーム（Monokaiテーマ各種） |
+| `java/` | Javaコードフォーマッター設定（Google Styleベースのフォーマットプロファイル） |
+| `ssh/` | SSHクライアント設定（`authorized_keys`） |
+| `sshd/` | SSHサーバー設定（`sshd_config`） |
+| `vscode/` | VSCodeの設定（`settings.json`、`keybindings.json`、Cline拡張設定） |
+| `vscode-insiders/` | VSCode Insidersの設定（`settings.json`、`keybindings.json`） |
+| `zsh/` | Zshシェル設定（`.zshrc`） |

--- a/init-mac.zsh
+++ b/init-mac.zsh
@@ -105,17 +105,30 @@ fi
 # @param command Command name (ex. 'git')
 # @param checkCommand Command to check if installed (ex. 'git --version')
 # @param installCommand Command to install (ex. 'brew install git')
+# @param updateCommand Command to update if already installed (ex. 'nix profile upgrade git') [optional]
 function install_command() {
   local name=$1
   local command=$2
   local checkCommand=$3
   local installCommand=$4
-  
+  local updateCommand=${5:-""}
+
   print_info "Checking ${name}... "
-  
+
   if eval "$checkCommand" &>/dev/null; then
-    print_success "Already installed"
-    return 0
+    if [[ -n "$updateCommand" ]]; then
+      print_info "Already installed. Updating... "
+      if eval "$updateCommand"; then
+        print_success "Updated successfully!"
+        return 0
+      else
+        print_error "Update failed"
+        return 1
+      fi
+    else
+      print_success "Already installed, skipping update"
+      return 0
+    fi
   else
     print_info "Installing... "
     if eval "$installCommand"; then
@@ -132,55 +145,55 @@ print_section "Installing Development Tools"
 
 
 # Git install
-install_command 'Git' 'git' 'which git' 'nix profile add nixpkgs#git'
+install_command 'Git' 'git' 'which git' 'nix profile add nixpkgs#git' 'nix profile upgrade git'
 
 # ghq install
-install_command 'ghq' 'ghq' 'ghq --version' 'nix profile add nixpkgs#ghq'
+install_command 'ghq' 'ghq' 'ghq --version' 'nix profile add nixpkgs#ghq' 'nix profile upgrade ghq'
 
 # GitHub CLI install
-install_command 'GitHub CLI' 'gh' 'gh --version' 'nix profile add nixpkgs#gh'
+install_command 'GitHub CLI' 'gh' 'gh --version' 'nix profile add nixpkgs#gh' 'nix profile upgrade gh'
 
 # curl install
-install_command 'curl' 'curl' 'which curl' 'nix profile add nixpkgs#curl'
+install_command 'curl' 'curl' 'which curl' 'nix profile add nixpkgs#curl' 'nix profile upgrade curl'
 
 # fzf install
-install_command 'fzf' 'fzf' 'fzf --version' 'nix profile add nixpkgs#fzf'
+install_command 'fzf' 'fzf' 'fzf --version' 'nix profile add nixpkgs#fzf' 'nix profile upgrade fzf'
 
 # mise install (multi-language version manager)
-install_command 'mise' 'mise' 'mise --version' 'nix profile add nixpkgs#mise'
+install_command 'mise' 'mise' 'mise --version' 'nix profile add nixpkgs#mise' 'nix profile upgrade mise'
 
 # Go install
-install_command 'Go' 'go' 'go version' 'nix profile add nixpkgs#go'
+install_command 'Go' 'go' 'go version' 'nix profile add nixpkgs#go' 'nix profile upgrade go'
 
 # SDKMAN install
-install_command 'SDKMAN' 'sdk' 'sdk version' 'curl -s "https://get.sdkman.io" | bash; source "$HOME/.sdkman/bin/sdkman-init.sh"'
+install_command 'SDKMAN' 'sdk' 'sdk version' 'curl -s "https://get.sdkman.io" | bash; source "$HOME/.sdkman/bin/sdkman-init.sh"' 'sdk selfupdate force'
 
 print_section "Installing mise-managed tools"
 
 # Python install via mise
-install_command 'Python (latest)' 'python' 'mise which python' 'mise use -g python@latest'
+install_command 'Python (latest)' 'python' 'mise which python' 'mise use -g python@latest' 'mise use -g python@latest'
 
 # Node.js install via mise
-install_command 'Node.js (latest LTS)' 'node' 'mise which node' 'mise use -g node@lts'
+install_command 'Node.js (latest LTS)' 'node' 'mise which node' 'mise use -g node@lts' 'mise use -g node@lts'
 
 # pnpm install via mise
-install_command 'pnpm' 'pnpm' 'mise which pnpm' 'mise use -g pnpm@latest'
+install_command 'pnpm' 'pnpm' 'mise which pnpm' 'mise use -g pnpm@latest' 'mise use -g pnpm@latest'
 
 # Bun install via mise
 # @see https://bun.sh/docs/installation
-install_command 'Bun' 'bun' 'mise which bun' 'mise use -g bun@latest'
+install_command 'Bun' 'bun' 'mise which bun' 'mise use -g bun@latest' 'mise use -g bun@latest'
 
 # Claude Code CLI install
-install_command 'Claude Code' 'claude' 'claude -v' 'curl -fsSL https://claude.ai/install.sh | bash'
+install_command 'Claude Code' 'claude' 'claude -v' 'curl -fsSL https://claude.ai/install.sh | bash' 'curl -fsSL https://claude.ai/install.sh | bash'
 
 # Codex CLI install
-install_command 'Codex CLI' 'codex' 'codex --version' 'brew install codex'
+install_command 'Codex CLI' 'codex' 'codex --version' 'brew install codex' 'brew upgrade codex'
 
 # AWS CLI install
-install_command 'AWS CLI' 'aws' 'aws --version' 'nix profile add nixpkgs#awscli2'
+install_command 'AWS CLI' 'aws' 'aws --version' 'nix profile add nixpkgs#awscli2' 'nix profile upgrade awscli2'
 
 # AWS SAM CLI install
-install_command 'AWS SAM CLI' 'sam' 'sam --version' 'nix profile add nixpkgs#aws-sam-cli'
+install_command 'AWS SAM CLI' 'sam' 'sam --version' 'nix profile add nixpkgs#aws-sam-cli' 'nix profile upgrade aws-sam-cli'
 
 # Font Fira Code install
 # Bug: Font installation path issue, manually move and remove from brew
@@ -188,15 +201,18 @@ install_command 'Font Fira Code' 'FiraCode' 'ls $HOME/Library/Fonts/FiraCode-Reg
 
 # ngrok install
 # @see https://ngrok.com/docs/getting-started/
-install_command 'ngrok' 'ngrok' 'ngrok version' 'brew install ngrok'
+install_command 'ngrok' 'ngrok' 'ngrok version' 'brew install ngrok' 'brew upgrade ngrok'
 
 # Stripe CLI install
 # @see https://docs.stripe.com/stripe-cli
-install_command 'Stripe CLI' 'stripe' 'stripe version' 'nix profile add nixpkgs#stripe-cli'
+install_command 'Stripe CLI' 'stripe' 'stripe version' 'nix profile add nixpkgs#stripe-cli' 'nix profile upgrade stripe-cli'
 
 # VHS install
 # @see https://github.com/charmbracelet/vhs
-install_command 'VHS' 'vhs' 'vhs --version' 'nix profile add nixpkgs#vhs'
+install_command 'VHS' 'vhs' 'vhs --version' 'nix profile add nixpkgs#vhs' 'nix profile upgrade vhs'
+
+# tmux install
+install_command 'tmux' 'tmux' 'tmux -V' 'nix profile add nixpkgs#tmux' 'nix profile upgrade tmux'
 
 print_section "Installing Java"
 # After setting sdk command path in .zshrc, install Java
@@ -232,6 +248,10 @@ print_success "VSCode configuration files created"
 ln -nfs $SCRIPT_DIR/vscode-insiders/settings.json $HOME/Library/Application\ Support/Code\ -\ Insiders/User/settings.json
 ln -nfs $SCRIPT_DIR/vscode-insiders/keybindings.json $HOME/Library/Application\ Support/Code\ -\ Insiders/User/keybindings.json
 print_success "VSCode Insiders configuration files created"
+
+# tmux configuration
+ln -nfs $SCRIPT_DIR/tmux/.tmux.conf $HOME/
+print_success "tmux configuration file created"
 
 # Claude Code user-level configuration
 print_section "Claude Code User Configuration"

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -1,0 +1,11 @@
+# | でペインを縦分割する
+bind | split-window -h
+
+# - でペインを横分割する
+bind - split-window -v
+
+# t でウィンドウ一覧から選択して切り替える
+bind t choose-tree -w
+
+# T で新しいウィンドウを開く
+bind T new-window

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -12,7 +12,7 @@ else
 fi
 
 # Alias
-alias cdproject='cd ~/Documents/Project/'
+alias cdproject='cd ~/Documents/Project/github.com'
 alias ..='cd ..'
 alias ls='ls -F'
 alias la='ls -A'

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -56,3 +56,8 @@ local p_current="%F{green}@%2d%f"
 local p_history="%F{yellow}%!%f"
 local p_endmark="%B%(?,%F{green}$,%F{red}!!\$!!)%f%b"
 PROMPT="$p_current $p_history$p_endmark"
+
+# tmux auto-attach (interactive, non-tmux, non-vscode terminal)
+if [[ $- == *i* ]] && [[ -z "$TMUX" ]] && [[ "$TERM_PROGRAM" != "vscode" ]]; then
+  tmux new-session -A -s main
+fi


### PR DESCRIPTION
## Summary

- `tmux/.tmux.conf` を新規追加し、tmux設定をdotfilesで管理できるようにした
- `init-mac.zsh` の `install_command` 関数に `updateCommand` 引数を追加し、インストール済みツールの自動更新に対応した
- `zsh/.zshrc` にtmux自動アタッチ設定を追加（VSCodeターミナル・非インタラクティブシェルは除外）

## Test plan

- [x] `init-mac.zsh` を実行し、既インストール済みツールが `updateCommand` で更新されることを確認
- [x] `tmux/.tmux.conf` のシンボリックリンクが `$HOME/.tmux.conf` に作成されることを確認
- [x] 新しいシェルセッション開始時にtmuxが自動アタッチされることを確認（VSCodeターミナルでは自動アタッチされないことも確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)