### PR TITLE
fix(tmux): プレフィックスキーをCtrl+bからCtrl+xに変更

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -1,3 +1,8 @@
+# プレフィックスキーをCtrl+xに変更
+unbind C-b
+set -g prefix C-x
+bind C-x send-prefix
+
 # | でペインを縦分割する
 bind | split-window -h
 


### PR DESCRIPTION
## Summary

- tmuxのプレフィックスキーをデフォルトの`Ctrl+b`から`Ctrl+x`に変更
- `unbind C-b` で既存バインドを解除し `set -g prefix C-x` で新しいプレフィックスを設定
- `bind C-x send-prefix` でプレフィックスキー自体を送信できるよう設定

## Test plan

- [x] tmuxを起動し、`Ctrl+x` がプレフィックスキーとして機能することを確認
- [x] `Ctrl+x |` でペインの縦分割ができることを確認
- [x] `Ctrl+x -` でペインの横分割ができることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)