### PR TITLE
feat(tmux): ステータスラインの設定追加とコメント整備

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -1,6 +1,7 @@
-# プレフィックスキーをCtrl+xに変更
+# プレフィックスキーをCtrl+xに変更（デフォルトはCtrl+b）
 unbind C-b
 set -g prefix C-x
+# Ctrl+x を2回押すと、プレフィックスキーをそのまま送信する
 bind C-x send-prefix
 
 # | でペインを縦分割する
@@ -14,3 +15,26 @@ bind t choose-tree -w
 
 # T で新しいウィンドウを開く
 bind T new-window
+
+# ウィンドウ番号を1始まりにする（デフォルトは0）
+set -g base-index 1
+# ペイン番号を1始まりにする（デフォルトは0）
+set -g pane-base-index 1
+
+# ステータスラインを5秒ごとに更新する
+set -g status-interval 5
+
+# 左側: ホスト名とセッション名を表示する
+set -g status-left "[#h:#S] | "
+# 左側の最大文字数
+set -g status-left-length 45
+
+# ウィンドウリスト: インデックス:名前の形式で表示する
+set -g window-status-format "#I:#W"
+# 現在のウィンドウは [ ] で囲んで強調する
+set -g window-status-current-format "[#I:#W]"
+
+# 右側: プレフィックス状態（押下中のみ表示）| ペイン番号/ペイン総数 | 日時
+set -g status-right "#{?client_prefix,[PREFIX] | ,}Pane:#P/#{window_panes} | %Y-%m-%d %H:%M"
+# 右側の最大文字数
+set -g status-right-length 50


### PR DESCRIPTION
## Summary

- ウィンドウ・ペイン番号を1始まりに変更（`base-index`, `pane-base-index`）
- ステータスライン左側にホスト名・セッション名を表示
- ステータスライン右側にプレフィックス状態・ペイン番号/総数・日時を表示
- 各設定行に説明コメントを追加

## Test plan

- [ ] tmuxを起動してステータスライン左側に `[ホスト名:セッション名]` が表示されること
- [ ] ステータスライン右側に `Pane:1/1 | 日時` が表示されること
- [ ] `Ctrl+x` を押したとき `[PREFIX]` が表示されること
- [ ] ペインを分割したとき番号が1始まりで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)