### PR TITLE
chore(.claude): プロジェクト設定にgit pushの自動許可を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,7 @@
       "Bash(git checkout:*)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
+      "Bash(git push:*)",
       "Bash(gh pr create:*)"
     ]
   },


### PR DESCRIPTION
## Summary

- `.claude/settings.json` の `permissions.allow` に `Bash(git push:*)` を追加
- git-ship スキル実行時に `git push` ステップが自動承認されるようになる
- ユーザー設定の `deny: ["Bash(git push --force:*)"]` は引き続き有効

## Test plan

- [ ] このリポジトリで `/git-ship` を実行し、`git push` ステップで確認プロンプトが表示されないことを確認
- [ ] `git push --force` は拒否されることを確認（ユーザーレベルの deny が有効）

🤖 Generated with [Claude Code](https://claude.com/claude-code)