### PR TITLE
chore(tmux): プレフィックスキーをCtrl+Spaceに変更し、ステータスラインを簡略化

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -1,8 +1,8 @@
-# プレフィックスキーをCtrl+xに変更（デフォルトはCtrl+b）
+# プレフィックスキーをCtrl+Spaceに変更（デフォルトはCtrl+b）
 unbind C-b
-set -g prefix C-x
-# Ctrl+x を2回押すと、プレフィックスキーをそのまま送信する
-bind C-x send-prefix
+set -g prefix C-Space
+# Ctrl+Space を2回押すと、プレフィックスキーをそのまま送信する
+bind C-Space send-prefix
 
 # | でペインを縦分割する
 bind | split-window -h
@@ -24,10 +24,10 @@ set -g pane-base-index 1
 # ステータスラインを5秒ごとに更新する
 set -g status-interval 5
 
-# 左側: ホスト名とセッション名を表示する
-set -g status-left "[#h:#S] | "
+# 左側: セッション名を表示する
+set -g status-left "[#S] | "
 # 左側の最大文字数
-set -g status-left-length 45
+set -g status-left-length 20
 
 # ウィンドウリスト: インデックス:名前の形式で表示する
 set -g window-status-format "#I:#W"


### PR DESCRIPTION
## Summary

- tmuxのプレフィックスキーを `Ctrl+x` から `Ctrl+Space` に変更（左手Ctrl+右手スペースで両手使用可能）
- ステータスライン左側からホスト名（`#h`）を削除し、セッション名（`#S`）のみの表示に簡略化
- ステータスライン左側の最大文字数を45→20に削減

## Test plan

- [x] `tmux source-file ~/.tmux.conf` で設定を再読み込みする
- [x] `Ctrl+Space` でプレフィックスが動作することを確認する
- [x] ステータスラインにセッション名のみが表示されていることを確認する（ホスト名なし）
- [x] スマートフォン等の狭い画面でステータスラインが見やすくなっていることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)