### PR TITLE
chore(zsh): cdprojectエイリアスのパスをDocuments/Projectに変更

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -12,7 +12,7 @@ else
 fi
 
 # Alias
-alias cdproject='cd ~/Documents/Project/github.com'
+alias cdproject='cd ~/Documents/Project'
 alias ..='cd ..'
 alias ls='ls -F'
 alias la='ls -A'


### PR DESCRIPTION
## Summary

- `cdproject` エイリアスのパスを `~/Documents/Project/github.com` から `~/Documents/Project` に変更
- `github.com` ディレクトリを省くことで、より上位のプロジェクトディレクトリに直接移動できるようになる

## Test plan

- [x] `source ~/.zshrc` でzsh設定を再読み込みする
- [x] `cdproject` を実行して `~/Documents/Project` に移動することを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)