### PR TITLE
chore(zsh): SSH接続時にtmuxセッションをremoteに分離する

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -58,6 +58,18 @@ local p_endmark="%B%(?,%F{green}$,%F{red}!!\$!!)%f%b"
 PROMPT="$p_current $p_history$p_endmark"
 
 # tmux auto-attach (interactive, non-tmux, non-vscode terminal)
+# $-はシェルオプションフラグの文字列。"i"が含まれていればインタラクティブシェル（手動操作用）
+# -z "$TMUX" はtmux内でなければtrue（二重起動を防ぐ）
+# "$TERM_PROGRAM" != "vscode" はVSCode統合ターミナルを除外
 if [[ $- == *i* ]] && [[ -z "$TMUX" ]] && [[ "$TERM_PROGRAM" != "vscode" ]]; then
-  tmux new-session -A -s main
+  # $SSH_CLIENT はSSH接続元のIPとポートが入る変数（SSH接続時のみセットされる）
+  # $SSH_TTY はSSH接続時に割り当てられた端末デバイスのパス（SSH接続時のみセットされる）
+  # どちらか一方でもセットされていればSSH接続と判定する
+  if [[ -n "$SSH_CLIENT" ]] || [[ -n "$SSH_TTY" ]]; then
+    # SSH接続時は専用セッション "remote" にアタッチ（なければ新規作成）
+    tmux new-session -A -s remote
+  else
+    # ローカル起動時はメインセッション "main" にアタッチ（なければ新規作成）
+    tmux new-session -A -s main
+  fi
 fi


### PR DESCRIPTION
## Summary

- `$SSH_CLIENT` / `$SSH_TTY` 変数でSSH接続を判定する処理を追加
- SSH接続時は `remote` セッション、ローカル起動時は `main` セッションにアタッチするよう分離
- 各条件の意味を説明するコメントを追記

## Test plan

- [x] ローカルで新しいターミナルを開き、tmux `main` セッションに自動アタッチされることを確認
- [x] SSHでリモートログインし、tmux `remote` セッションに自動アタッチされることを確認
- [x] VSCode統合ターミナルではtmuxが起動しないことを確認
- [x] tmux内では自動アタッチが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)