### PR TITLE
chore(tmux): tmuxのインストール・設定・自動アタッチを削除

### DIFF
--- a/init-mac.zsh
+++ b/init-mac.zsh
@@ -211,9 +211,6 @@ install_command 'Stripe CLI' 'stripe' 'stripe version' 'nix profile add nixpkgs#
 # @see https://github.com/charmbracelet/vhs
 install_command 'VHS' 'vhs' 'vhs --version' 'nix profile add nixpkgs#vhs' 'nix profile upgrade vhs'
 
-# tmux install
-install_command 'tmux' 'tmux' 'tmux -V' 'nix profile add nixpkgs#tmux' 'nix profile upgrade tmux'
-
 print_section "Installing Java"
 # After setting sdk command path in .zshrc, install Java
 install_command 'Java 11' 'java11' 'sdk home java 11.0.29-amzn' 'sdk install java 11.0.29-amzn'
@@ -248,10 +245,6 @@ print_success "VSCode configuration files created"
 ln -nfs $SCRIPT_DIR/vscode-insiders/settings.json $HOME/Library/Application\ Support/Code\ -\ Insiders/User/settings.json
 ln -nfs $SCRIPT_DIR/vscode-insiders/keybindings.json $HOME/Library/Application\ Support/Code\ -\ Insiders/User/keybindings.json
 print_success "VSCode Insiders configuration files created"
-
-# tmux configuration
-ln -nfs $SCRIPT_DIR/tmux/.tmux.conf $HOME/
-print_success "tmux configuration file created"
 
 # Claude Code user-level configuration
 print_section "Claude Code User Configuration"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -57,19 +57,3 @@ local p_history="%F{yellow}%!%f"
 local p_endmark="%B%(?,%F{green}$,%F{red}!!\$!!)%f%b"
 PROMPT="$p_current $p_history$p_endmark"
 
-# tmux auto-attach (interactive, non-tmux, non-vscode terminal)
-# $-はシェルオプションフラグの文字列。"i"が含まれていればインタラクティブシェル（手動操作用）
-# -z "$TMUX" はtmux内でなければtrue（二重起動を防ぐ）
-# "$TERM_PROGRAM" != "vscode" はVSCode統合ターミナルを除外
-if [[ $- == *i* ]] && [[ -z "$TMUX" ]] && [[ "$TERM_PROGRAM" != "vscode" ]]; then
-  # $SSH_CLIENT はSSH接続元のIPとポートが入る変数（SSH接続時のみセットされる）
-  # $SSH_TTY はSSH接続時に割り当てられた端末デバイスのパス（SSH接続時のみセットされる）
-  # どちらか一方でもセットされていればSSH接続と判定する
-  if [[ -n "$SSH_CLIENT" ]] || [[ -n "$SSH_TTY" ]]; then
-    # SSH接続時は専用セッション "remote" にアタッチ（なければ新規作成）
-    tmux new-session -A -s remote
-  else
-    # ローカル起動時はメインセッション "main" にアタッチ（なければ新規作成）
-    tmux new-session -A -s main
-  fi
-fi


### PR DESCRIPTION
## Summary

- `init-mac.zsh` からtmuxのインストール処理（`nix profile add nixpkgs#tmux`）を削除
- `init-mac.zsh` からtmux設定ファイルのシンボリックリンク作成処理を削除
- `zsh/.zshrc` からtmux自動アタッチ設定（SSH接続時・ローカル起動時の両対応）を削除

## Test plan

- [x] `init-mac.zsh` を実行してもtmuxがインストールされないことを確認
- [x] 新しいターミナルを起動してもtmuxセッションに自動アタッチされないことを確認
- [x] SSH接続時にもtmuxセッションが起動しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)